### PR TITLE
fix: memo bug

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,23 +48,26 @@ impl Exp{
                         match p_rule.rules.get(sym){
                             Some(ref e) => if e.parse(p){
                                initialtree.push(Tree::Node{sym: sym, child: p.tree.clone()});
-                                p.memos.insert((p.pos, sym), Memos::Memo{pos: p.pos,child: p.tree.clone()});
+                                p.memos.insert((old.pos, sym), Memos::Memo{pos: p.pos,child: p.tree.clone()});
                                 p.tree = initialtree.clone();
                             //    println!("{:?}",p.tree);
                                 true
                             }else{
-                                *p = old;
+                                p.memos.insert((old.pos, sym), Memos::Fail);
+                                p.pos = old.pos;
+                                p.tree = old.tree;
                                 false
                             },
                             None => panic!("There is no rule. {}",sym),
                         }
                     },
                     Some(ref memo) => {
-                        println!("*");
+                        //println!("*");
                         match memo{
                             &Memos::Fail => return false,
                             &Memos::Memo{ref pos,child: ref newchild} => {
                                 p.tree.push(Tree::Node{sym: sym,child: newchild.clone()});
+                                p.pos = *pos;
                                 true
                             }, 
                         }
@@ -77,11 +80,13 @@ impl Exp{
                     if e2.parse(p){
                         true
                     }else{
-                        *p = old;
+                        p.pos = old.pos;
+                        p.tree = old.tree.clone();
                         false
                     }
                 }else{
-                    *p = old;
+                    p.pos = old.pos;
+                    p.tree = old.tree;
                     false
                 }
             },
@@ -90,11 +95,13 @@ impl Exp{
                 if e1.parse(p){
                     true
                 }else{
-                    *p = old.clone();
+                    p.pos = old.pos;
+                    p.tree = old.tree.clone();
                     if e2.parse(p){
                         true
                     }else{
-                        *p = old;
+                        p.pos = old.pos;
+                        p.tree = old.tree;
                         false
                     }
                 }
@@ -103,7 +110,8 @@ impl Exp{
                 loop{
                     let old = p.clone();
                     if !e.parse(p){
-                        *p = old;
+                        p.pos = old.pos;
+                        p.tree = old.tree;
                         break;
                     }
                 }
@@ -114,17 +122,20 @@ impl Exp{
                 if e.parse(p){
                     true
                 }else{
-                    *p = old;
+                    p.pos = old.pos;
+                    p.tree = old.tree;
                     true
                 }
             },
             &Exp::Not{ref e} =>{
                 let old = p.clone();
                 if e.parse(p){
-                    *p = old;
+                    p.pos = old.pos;
+                    p.tree = old.tree;
                     false
                 }else{
-                    *p = old;
+                    p.pos = old.pos;
+                    p.tree = old.tree;
                     true
                 }
             },

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use peg_parser_combinator::*;
 fn main() {
 //    println!("{}", Exp::Empty.parse(&mut ParserContext::new("hello".to_string().into_bytes(),HashMap::new())));
 
-    let s: &'static str = "(((((1)))))";
+    let s: &'static str = "((((((((((1))))))))))";
     let mut rules = HashMap::new();
     rules.insert("P",choice(seq(char('('),seq(sym("A"),char(')'))),char('1')));
     rules.insert("A",choice(seq(sym("P"),seq(char('+'),sym("A"))),choice(seq(sym("P"),seq(char('-'),sym("A"))),sym("P"))));
@@ -25,7 +25,7 @@ fn main() {
     Exp::Symbol{sym:&"S"}.parse(&mut p);
 */
     println!("{}",p.tree[0].two_string());
-    println!("memosu{:?}",p.memos);
+    //println!("memosu{:?}",p.memos);
 
         
 }

--- a/tests/exp.rs
+++ b/tests/exp.rs
@@ -10,151 +10,134 @@ mod exp{
     #[test]
     fn anychar1() {
         let s: &'static str = "a";
-        let mut child = Vec::new();
         let mut p: ParserContext = ParserContext::new(String::from(s).into_bytes(),HashMap::new());
         let peg: Exp = any();
-        assert!(peg.parse(&mut p,&mut child) && (p.pos == s.len()));
+        assert!(peg.parse(&mut p) && (p.pos == s.len()));
     }
 
     #[test]
     fn anychar2() {
         let s: &'static str = "aaa";
-        let mut child = Vec::new();
         let mut p: ParserContext = ParserContext::new(String::from(s).into_bytes(),HashMap::new());
         let peg: Exp = seq(any(),seq(any(),any()));
 //      let peg: Exp =  Exp::Seq{e1: Box::new(Exp::AnyChar), e2: Box::new(Exp::Seq{e1: Box::new(Exp::AnyChar), e2: Box::new(Exp::AnyChar)})};
-        assert!(peg.parse(&mut p,&mut child) && (p.pos == s.len()));
+        assert!(peg.parse(&mut p) && (p.pos == s.len()));
     }
 
     #[test]
     fn char1() {
         let s: &'static str = "a";
-        let mut child = Vec::new();
         let mut p: ParserContext = ParserContext::new(String::from(s).into_bytes(),HashMap::new());
         let peg: Exp = Exp::Char{c: 'a'};
-        assert!(peg.parse(&mut p,&mut child) && (p.pos == s.len()));
+        assert!(peg.parse(&mut p) && (p.pos == s.len()));
     }
 
     #[test]
     fn char2() {
         let s: &'static str = "aaa";
-        let mut child = Vec::new();
         let mut p: ParserContext = ParserContext::new(String::from(s).into_bytes(),HashMap::new());
         let peg: Exp = Exp::Seq{e1: Box::new(Exp::Char{c: 'a'}), e2: Box::new(Exp::Seq{e1: Box::new(Exp::Char{c: 'a'}), e2: Box::new(Exp::Char{c: 'a'})})};
-        assert!(peg.parse(&mut p,&mut child) && (p.pos == s.len()));
+        assert!(peg.parse(&mut p) && (p.pos == s.len()));
     }
     #[test]
     fn choice1() {
         let s: &'static str = "a";
-        let mut child = Vec::new();
         let mut p: ParserContext = ParserContext::new(String::from(s).into_bytes(),HashMap::new());
         let peg: Exp = Exp::Choice{e1: Box::new(Exp::Char{c: 'a'}),e2: Box::new(Exp::Char{c: 'b'})};
-        assert!(peg.parse(&mut p,&mut child) && (p.pos == s.len()));
+        assert!(peg.parse(&mut p) && (p.pos == s.len()));
     }
     #[test]
     fn choice2() {
         let s: &'static str = "b";
-        let mut child = Vec::new();
         let mut p: ParserContext = ParserContext::new(String::from(s).into_bytes(),HashMap::new());
         let peg: Exp = Exp::Choice{e1: Box::new(Exp::Char{c: 'a'}),e2: Box::new(Exp::Char{c: 'b'})};
-        assert!(peg.parse(&mut p,&mut child) && (p.pos == s.len()));
+        assert!(peg.parse(&mut p) && (p.pos == s.len()));
     }
     #[test]
     fn zero_or_more1() {
         let s: &'static str = "";
-        let mut child = Vec::new();
         let mut p: ParserContext = ParserContext::new(String::from(s).into_bytes(),HashMap::new());
         let peg: Exp = Exp::Rep{e: Box::new(Exp::Char{c: 'a'})};
-        assert!(peg.parse(&mut p,&mut child) && (p.pos == s.len()));
+        assert!(peg.parse(&mut p) && (p.pos == s.len()));
     }
     #[test]
     fn zero_or_more2() {
         let s: &'static str = "aaaaaaaaaaaaaaaaaaaa";
-        let mut child = Vec::new();
         let mut p: ParserContext = ParserContext::new(String::from(s).into_bytes(),HashMap::new());
         let peg: Exp = Exp::Rep{e: Box::new(Exp::Char{c: 'a'})};
-        assert!(peg.parse(&mut p,&mut child) && (p.pos == s.len()));
+        assert!(peg.parse(&mut p) && (p.pos == s.len()));
     }
     #[test]
     fn one_or_more1() {
         let s: &'static str = "a";
-        let mut child = Vec::new();
         let mut p: ParserContext = ParserContext::new(String::from(s).into_bytes(),HashMap::new());
         let peg: Exp = Exp::Seq{e1: Box::new(Exp::Char{c: 'a'}),e2: Box::new(Exp::Rep{e: Box::new(Exp::Char{c: 'a'})})};
-        assert!(peg.parse(&mut p,&mut child) && (p.pos == s.len()));
+        assert!(peg.parse(&mut p) && (p.pos == s.len()));
     }
     #[test]
     fn one_or_more2() {
         let s: &'static str = "aaaaaaaaaaaaaaaaaaa";
-        let mut child = Vec::new();
         let mut p: ParserContext = ParserContext::new(String::from(s).into_bytes(),HashMap::new());
         let peg: Exp = Exp::Seq{e1: Box::new(Exp::Char{c: 'a'}),e2: Box::new(Exp::Rep{e: Box::new(Exp::Char{c: 'a'})})};
-        assert!(peg.parse(&mut p,&mut child) && (p.pos == s.len()));
+        assert!(peg.parse(&mut p) && (p.pos == s.len()));
     }
     #[test]
     fn opt1() {
         let s: &'static str = "";
-        let mut child = Vec::new();
         let mut p: ParserContext = ParserContext::new(String::from(s).into_bytes(),HashMap::new());
         let peg: Exp = Exp::Opt{e: Box::new(Exp::Char{c: 'a'})};
-        assert!(peg.parse(&mut p,&mut child) && (p.pos == s.len()));
+        assert!(peg.parse(&mut p) && (p.pos == s.len()));
     }
     #[test]
     fn opt2() {
         let s: &'static str = "a";
-        let mut child = Vec::new();
         let mut p: ParserContext = ParserContext::new(String::from(s).into_bytes(),HashMap::new());
         let peg: Exp = Exp::Opt{e: Box::new(Exp::Char{c: 'a'})};
-        assert!(peg.parse(&mut p,&mut child) && (p.pos == s.len()));
+        assert!(peg.parse(&mut p) && (p.pos == s.len()));
     }
     #[test]
     fn not1() {
         let s: &'static str = "b";
-        let mut child = Vec::new();
         let mut p: ParserContext = ParserContext::new(String::from(s).into_bytes(),HashMap::new());
         let peg: Exp = Exp::Not{e: Box::new(Exp::Char{c: 'a'})};
-        assert!(peg.parse(&mut p,&mut child) && (p.pos == 0));
+        assert!(peg.parse(&mut p) && (p.pos == 0));
     }
     #[test]
     fn and1() {
         let s: &'static str = "a";
-        let mut child = Vec::new();
         let mut p: ParserContext = ParserContext::new(String::from(s).into_bytes(),HashMap::new());
         let peg: Exp = Exp::Not{e: Box::new(Exp::Not{e: Box::new(Exp::Char{c: 'a'})})};
-        assert!(peg.parse(&mut p,&mut child) && (p.pos == 0));
+        assert!(peg.parse(&mut p) && (p.pos == 0));
     }
     #[test]
     fn symbol1() {
         let s: &'static str = "ab";
         let mut rules = HashMap::new();
-        let mut child = Vec::new();
         rules.insert("A",Exp::Seq{e1: Box::new(Exp::Char{c: 'a'}),e2: Box::new(Exp::Symbol{sym: "B"})});
         rules.insert("B",Exp::Char{c: 'b'});
         let mut p: ParserContext = ParserContext::new(String::from(s).into_bytes(),rules.clone());
-        assert!(rules.get(&"A").unwrap().parse(&mut p,&mut child) && (p.pos == s.len()));
+        assert!(rules.get(&"A").unwrap().parse(&mut p) && (p.pos == s.len()));
     }
      #[test]
     fn math1() {
         let s: &'static str = "3-2-1";
         let mut rules = HashMap::new();
-        let mut child = Vec::new();
         rules.insert("EXP",seq(sym("PRODUCT"),rep0(choice(seq(char('+'),sym("PRODUCT")),seq(char('-'),sym("PRODUCT"))))));
         rules.insert("PRODUCT",seq(sym("NUM"),rep0(choice(seq(char('*'),sym("NUM")),seq(char('/'),sym("NUM"))))));
         rules.insert("NUM",rep1(choice(char('0'),choice(char('1'),choice(char('2'),choice(char('3'),choice(char('4'),choice(char('5'),choice(char('6'),choice(char('7'),choice(char('8'),char('9'))))))))))));
         let mut p: ParserContext = ParserContext::new(String::from(s).into_bytes(),rules.clone());
-        assert!(rules.get(&"EXP").unwrap().parse(&mut p,&mut child) && (p.pos == s.len()));
+        assert!(rules.get(&"EXP").unwrap().parse(&mut p) && (p.pos == s.len()));
     }
      #[test]
     fn math2() {
         let s: &'static str = "3+2+1";
         let mut rules = HashMap::new();
-        let mut child = Vec::new();
         rules.insert("EXP",seq(sym("PRODUCT"),rep0(choice(seq(char('+'),sym("PRODUCT")),seq(char('-'),sym("PRODUCT"))))));
         rules.insert("PRODUCT",seq(sym("NUM"),rep0(choice(seq(char('*'),sym("NUM")),seq(char('/'),sym("NUM"))))));
         rules.insert("NUM",rep1(choice(char('0'),choice(char('1'),choice(char('2'),choice(char('3'),choice(char('4'),choice(char('5'),choice(char('6'),choice(char('7'),choice(char('8'),char('9'))))))))))));
         let mut p: ParserContext = ParserContext::new(String::from(s).into_bytes(),rules.clone());
-        assert!(Exp::Symbol{sym: &"EXP"}.parse(&mut p,&mut child) && (p.pos == s.len()));
-        assert!(child[0].two_string() == "[EXP [PRODUCT [NUM 3]] + [PRODUCT [NUM 2]] + [PRODUCT [NUM 1]]]")
+        assert!(Exp::Symbol{sym: &"EXP"}.parse(&mut p) && (p.pos == s.len()));
+        assert!(p.tree[0].two_string() == "[EXP [PRODUCT [NUM 3]] + [PRODUCT [NUM 2]] + [PRODUCT [NUM 1]]]")
     }
 
     #[test]
@@ -164,34 +147,31 @@ mod exp{
         rules.insert("S",seq(sym("A"),sym("BC")));
         rules.insert("A",char('a'));
         rules.insert("BC",seq(char('b'),char('c')));  
-        let mut child = Vec::new();
         let mut p: ParserContext = ParserContext::new(String::from(s).into_bytes(),rules.clone());
-        Exp::Symbol{sym: &"S"}.parse(&mut p,&mut child);
-        assert!(child[0].two_string() == "[S [A a] [BC b c]]");
+        Exp::Symbol{sym: &"S"}.parse(&mut p);
+        assert!(p.tree[0].two_string() == "[S [A a] [BC b c]]");
     }
 
     #[test]
     fn cabcat() {
         let s: &'static str = "cat";
         let mut rules = HashMap::new();
-        let mut child = Vec::new();
         rules.insert("S",choice(sym("CAB"),sym("CAT")));
         rules.insert("CAB",seq(char('c'),seq(char('a'),char('b'))));
         rules.insert("CAT",seq(char('c'),seq(char('a'),char('t'))));
         let mut p: ParserContext = ParserContext::new(String::from(s).into_bytes(),rules.clone());
-        Exp::Symbol{sym: &"S"}.parse(&mut p,&mut child);
-        assert!(child[0].two_string() == "[S [CAT c a t]]")
+        Exp::Symbol{sym: &"S"}.parse(&mut p);
+        assert!(p.tree[0].two_string() == "[S [CAT c a t]]")
     }
 
     #[test]
     fn hayasa() {
         let s: &'static str = "(((((((1)))))))";
         let mut rules = HashMap::new();
-        let mut child = Vec::new();
         rules.insert("P",choice(seq(char('('),seq(sym("A"),char(')'))),char('1')));
         rules.insert("A",choice(seq(sym("P"),seq(char('+'),sym("A"))),choice(seq(sym("P"),seq(char('-'),sym("A"))),sym("P"))));
         let mut p: ParserContext = ParserContext::new(String::from(s).into_bytes(),rules.clone());
-        assert!(rules.get(&"A").unwrap().parse(&mut p,&mut child) && (p.pos == s.len()));
+        assert!(rules.get(&"A").unwrap().parse(&mut p) && (p.pos == s.len()));
  
     }
 


### PR DESCRIPTION
ささっとメモ化のバグをとっておきました。
原因はメモするときのkeyである(pos, sym)のposがparse後の位置になっていてメモが引かれないというものでした。
バックトラック用にとっておいたold.posに変更したら動きました。

その他テストに修正などやっておきました。
詳しくは変更部分を参照してください。